### PR TITLE
Adding WattSeconds that has been consumed since the last request

### DIFF
--- a/src/modules/MyStromSwitch.ts
+++ b/src/modules/MyStromSwitch.ts
@@ -23,6 +23,7 @@ export class MyStromSwitch {
     switchStatus.power = result.data.power;
     switchStatus.relay = result.data.relay;
     switchStatus.temperature = result.data.temperature;
+    switchStatus.wattSeconds = result.data.Ws;
 
     return switchStatus;
   }

--- a/src/modules/MyStromSwitch.ts
+++ b/src/modules/MyStromSwitch.ts
@@ -23,7 +23,7 @@ export class MyStromSwitch {
     switchStatus.power = result.data.power;
     switchStatus.relay = result.data.relay;
     switchStatus.temperature = result.data.temperature;
-    switchStatus.wattSeconds = result.data.Ws;
+    switchStatus.avgWattSeconds = result.data.Ws;
 
     return switchStatus;
   }

--- a/src/modules/MyStromSwitchStatus.ts
+++ b/src/modules/MyStromSwitchStatus.ts
@@ -5,4 +5,5 @@ export class MyStromSwitchStatus {
   public power: number | undefined;
   public relay: boolean | undefined;
   public temperature: number | undefined;
+  public avgWattSeconds: number | undefined;
 }

--- a/src/nodes/mystrom-switch-status/mystrom-switch-status.ts
+++ b/src/nodes/mystrom-switch-status/mystrom-switch-status.ts
@@ -20,6 +20,7 @@ const nodeInit: NodeInitializer = (RED): void => {
           power: myStromSwitchStatus.power,
           relay: myStromSwitchStatus.relay,
           temperature: myStromSwitchStatus.temperature,
+          avgWattSeconds: myStromSwitchStatus.avgWattSeconds,
         };
 
         this.status({ fill: 'green', shape: 'dot', text: 'successful' });


### PR DESCRIPTION
Added the output of how many Watt Seconds had been consumed since the last API Request.
@claudiospizzi I create a PR. I dont know exactly how to test this. Maybe you can check, if the values are read correctly.

In Postman, if i access http://10.10.10.50/report i get this JSON: 
`{
    "power": 0,
    "Ws": 0,
    "relay": true,
    "temperature": 21.316848754882812
}`
I really hope, that all i need to do is add 
    switchStatus.wattSeconds = result.data.Ws; to see the consumed wattSeconds

Thanks ;)